### PR TITLE
Changed the http method from post to get for redirect uri

### DIFF
--- a/packages/backend/lib/constructs/rest-api-construct.ts
+++ b/packages/backend/lib/constructs/rest-api-construct.ts
@@ -63,7 +63,7 @@ export class RestApiConstruct extends Construct {
 
 		// this adds a POST method to myapi.com/github/callback
 		githubCallbackResource.addMethod(
-			"POST",
+			"GET",
 			new LambdaIntegration(githubCallbackFunction),
 		);
 


### PR DESCRIPTION
As per the Github documentation, callback API should be a GET http method. So changed the HTTP method of callback API to GET.

Github doc - https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authenticating-to-the-rest-api-with-an-oauth-app#providing-a-callback
Issue - https://github.com/osguild/osguild/issues/46