### PR TITLE
Add Note.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 .env*
 !packages/ui/.env
 
+#Local Personal notes file
+notes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ dist-ssr
 !packages/ui/.env
 
 #Local Personal notes file
-notes.txt
+notes.md


### PR DESCRIPTION
I like to keep a local `notes.md` in the repo, for personal notes about process flow, commands, other things to remind me how to better operate in the repo. 

Please consider adding this to `.gitignore` so that it can be a universal concept. Really good notes should eventually be propagated to the `README.md`, but there are some instances where you just need a quick reminder. Works well paired with the [VSCode Markdown extension](https://code.visualstudio.com/api/extension-guides/markdown-extension):

<img width="970" height="771" alt="image" src="https://github.com/user-attachments/assets/8b8fd357-935e-4f25-8d6d-35b2ba3a1aee" />


